### PR TITLE
adding ability to have multiple message handling methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ foreman run web &
 ngrok http 3000
 ```
 
-Once the applicaiton is running you will then need to setup slack to be able to talk to it.  
-Take the ngrok url generated above and go to the `Event Subscriptions` page in the slack app setup.  
-Add the following to the `Request URL` - `https://NGROK_HOST_PORT/api/events`
+Once the application is running you will then need to setup slack to be able to talk to it.  
+1. Take the ngrok url generated above and go to the `Event Subscriptions` page in the slack app setup.  
+2. Add the following to the `Request URL` - `https://NGROK_HOST_PORT/api/events`
+2. Then you will need to subscribe the following "Bot Events"
+  * `app_mention`
+  * `message.im`
+  * `message.channels`
 
-Then you will need to subscribe the bot to the `app_mention` and `message.im` events below that.
+
 
 ## How to run the test suite
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ngrok http 3000
 Once the application is running you will then need to setup slack to be able to talk to it.  
 1. Take the ngrok url generated above and go to the `Event Subscriptions` page in the slack app setup.  
 2. Add the following to the `Request URL` - `https://NGROK_HOST_PORT/api/events`
-2. Then you will need to subscribe the following "Bot Events"
+3. Then you will need to subscribe the following "Bot Events"
   * `app_mention`
   * `message.im`
   * `message.channels`

--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -26,10 +26,15 @@ class Api::PeopleController < ApplicationApiController
     render json: MySlack::People.set_away(params[:user_id])
   end
 
+  def update_email
+    render json: MySlack::People.update_email(params[:user_id],params[:text])
+  end
+
   private
     def register_slack_params
       {
         slack_id: params[:user_id],
+        slack_email: params[:user_email],
         slack_handle: params[:user_name],
         available: true
       }

--- a/app/controllers/api/slack_controller.rb
+++ b/app/controllers/api/slack_controller.rb
@@ -20,7 +20,7 @@ class Api::SlackController < ApplicationApiController
       render json: { challenge: params[:challenge] }
     when 'event_callback'
       return unless event_params[:bot_id].nil?
-      
+
       render json: nil
       ProcessSlackMessageJob.perform_later(event_params.as_json)
     else
@@ -33,6 +33,6 @@ class Api::SlackController < ApplicationApiController
   private
 
   def event_params
-    params.require(:event).permit(:type, :text, :channel, :authed_users, :user, :ts, :event_ts, :bot_id, attachments: [])
+    params.require(:event).permit(:type, :text, :channel, :authed_users, :user, :ts, :event_ts, :bot_id, :client_msg_id, :channel_type, attachments: [])
   end
 end

--- a/app/controllers/api/slack_controller.rb
+++ b/app/controllers/api/slack_controller.rb
@@ -32,7 +32,7 @@ class Api::SlackController < ApplicationApiController
       render json: { challenge: params[:challenge] }
     when 'event_callback'
       return unless event_params[:bot_id].nil?
-      
+
       render json: nil
       ProcessSlackMessageJob.perform_later(event_params.as_json)
     else
@@ -45,7 +45,7 @@ class Api::SlackController < ApplicationApiController
   private
 
   def event_params
-    params.require(:event).permit(:type, :text, :channel, :authed_users, :user, :ts, :event_ts, :bot_id, attachments: [])
+    params.require(:event).permit(:type, :text, :channel, :authed_users, :user, :ts, :event_ts, :bot_id, :client_msg_id, :channel_type, attachments: [])
   end
 
 end

--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -4,7 +4,13 @@ class ApplicationApiController < ActionController::Base
   private
 
   def validate_token
-    if params[:token] != Rails.application.secrets.slack_token
+    # handle "payload" format
+    if !params[:payload].nil?
+      newparams = JSON.parse(params[:payload], :symbolize_names => true)
+    else
+      newparams = params
+    end  
+    if newparams[:token] != Rails.application.secrets.slack_token
       redirect_to api_invalid_token_url
     end
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -69,6 +69,6 @@ class PeopleController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def person_params
-      params.require(:person).permit(:name, :slack_id, :slack_handle, :available, :product_id)
+      params.require(:person).permit(:name, :slack_id, :slack_handle, :slack_email, :available, :product_id)
     end
 end

--- a/app/jobs/process_interactive_message_job.rb
+++ b/app/jobs/process_interactive_message_job.rb
@@ -1,0 +1,98 @@
+class ProcessInteractiveMessageJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_params)
+    # Do something later
+    case event_params['type']
+    when 'interactive_message'
+      process_interactive_message(event_params)
+    else
+      logger.info "We don't handle #{event_params['type']} yet"
+    end
+  end
+
+  def process_interactive_message(params)
+    
+    result = "pending"
+
+    # if we recieve a "Take" response from anyone, let them try and take the ticket
+    case params['actions'][0]['name']
+    when 'take'
+       result = ::MySlack::Tickets.confirm(params['actions'][0]['value'], params['user']['id'])
+    when 'unavailable'
+       person = Person.where('slack_handle like ?', params['user']['name']).first
+       if person
+            ticket = Ticket.where(zendesk_id: params['actions'][0]['value']).first
+	    if ticket
+
+	      logger.info "person: #{person.inspect}, ticket: #{ticket.inspect}"
+	      result = person.set_away()
+	      if person.set_away
+                 result = "person #{params['user']['id']} set to away"
+	      # if user is the assigned person for that ticket
+	      if ticket['person_id'] == person['id'] 
+	        result = ::MySlack::Tickets.deny(params['actions'][0]['value'], params['user']['id'])
+	      end
+
+   	      else 
+                  result = "Error trying to set #{params['user']['id']} away"
+              end
+          end
+       else
+       end
+
+    else
+      logger.info "Some weird response to ticket confirmation prompt? #{params['actions'][0]['name']}"
+    end
+    
+    message = params['previous_message'] || params['original_message']
+    finaltext = message['text'] || "no text... error"
+    finalattachments =  message['attachments']
+
+    logger.info "========== [ finaltext: #{finaltext} ] ========="
+    logger.info "========== [ finalattachments: #{finalattachments} ]========="
+    logger.info "========== [ result: #{result} ]========="
+
+    # if a ticket assignment has been successful, match the confirmation string and update the original message to reflect that    
+    if result.include?("assigned")
+      finaltext = "#{finaltext.gsub! 'awaiting confirmation...', result}"
+      finalattachments = []				    
+      logger.info "========== [ finaltext: #{finalattachments} ]========="
+    elsif result.include?("can't")
+    # if a ticket assignment is rejected, update status and re-roll
+      finaltext = "#{finaltext.gsub! 'awaiting confirmation...', result}"
+      logger.info "========== [ finaltext: #{finaltext} ]========="
+
+      newmess = ::MySlack::Tickets.assign(params['actions'][0]['value']).as_json
+      newmess[:channel] = params['channel']['id']
+      newmess[:as_user] = true
+      logger.info "REEEEROLLLLLLLLLLLL #{newmess}"
+      
+    elsif result.include?("away")
+    	   
+    else	  
+      finaltext = "#{finaltext} ... #{result}"
+    end
+
+
+
+    
+    logger.info "Confirmation response: #{finaltext} "	
+
+
+    if !newmess.nil?
+      ::MySlack::client.chat_postMessage(newmess)
+      finalattachments = []
+    end   
+      ::MySlack::client.chat_update({:ts=>params['message_ts'], :channel=>params['channel']['id'], 
+                                      :text => finaltext,
+                                      :attachments => finalattachments})
+
+       
+
+  end
+
+  def find_person(id)
+  end
+
+end

--- a/app/jobs/process_slack_message_job.rb
+++ b/app/jobs/process_slack_message_job.rb
@@ -16,7 +16,6 @@ class ProcessSlackMessageJob < ApplicationJob
   def process_app_mention(mention)
     logger.info mention.inspect
     msg = Slack::Messages::Formatting.unescape(mention['text'])
-    # keyword, text = message_keyword(msg)
 
     message = ::MySlack::Commands.process(msg, mention)
     ::MySlack::client.chat_postMessage(message) unless message.nil?

--- a/app/jobs/process_slack_message_job.rb
+++ b/app/jobs/process_slack_message_job.rb
@@ -14,17 +14,9 @@ class ProcessSlackMessageJob < ApplicationJob
   def process_app_mention(mention)
     logger.info mention.inspect
     msg = Slack::Messages::Formatting.unescape(mention['text'])
-    # keyword, text = message_keyword(msg)
 
     message = ::MySlack::Commands.process(msg, mention)
 
     ::MySlack::client.chat_postMessage(message) unless message.nil?
-  end
-
-  def bot_match(word)
-    /@(\w+) #{word}/
-  end
-
-  def find_person(id)
   end
 end

--- a/app/jobs/process_slack_message_job.rb
+++ b/app/jobs/process_slack_message_job.rb
@@ -14,26 +14,11 @@ class ProcessSlackMessageJob < ApplicationJob
   end
 
   def process_app_mention(mention)
+    logger.info mention.inspect
     msg = Slack::Messages::Formatting.unescape(mention['text'])
-    keyword, text = message_keyword(msg)
+    # keyword, text = message_keyword(msg)
 
-    message = ::MySlack::Commands.process(keyword, text, mention)
-    logger.info "RESPOOOOOOONSE #{message.inspect}"
-    ::MySlack::client.chat_postMessage(message)
-  end
-
-  def message_keyword(text)
-    words = text.split(' ')
-    if words.first =~ /@[\w]+/
-      words.shift
-    end
-    [words.shift, words.join(' ')]
-  end
-
-  def bot_match(word)
-    /@(\w+) #{word}/
-  end
-
-  def find_person(id)
+    message = ::MySlack::Commands.process(msg, mention)
+    ::MySlack::client.chat_postMessage(message) unless message.nil?
   end
 end

--- a/app/jobs/process_slack_message_job.rb
+++ b/app/jobs/process_slack_message_job.rb
@@ -5,7 +5,9 @@ class ProcessSlackMessageJob < ApplicationJob
     # Do something later
     case event_params['type']
     when 'app_mention', 'message'
-      process_app_mention(event_params)
+      if !event_params['text'].nil? 
+        process_app_mention(event_params)
+      end
     else
       logger.info "We don't handle #{event_params['type']} yet"
     end
@@ -16,7 +18,7 @@ class ProcessSlackMessageJob < ApplicationJob
     keyword, text = message_keyword(msg)
 
     message = ::MySlack::Commands.process(keyword, text, mention)
-
+    logger.info "RESPOOOOOOONSE #{message.inspect}"
     ::MySlack::client.chat_postMessage(message)
   end
 

--- a/app/jobs/process_slack_message_job.rb
+++ b/app/jobs/process_slack_message_job.rb
@@ -12,20 +12,13 @@ class ProcessSlackMessageJob < ApplicationJob
   end
 
   def process_app_mention(mention)
+    logger.info mention.inspect
     msg = Slack::Messages::Formatting.unescape(mention['text'])
-    keyword, text = message_keyword(msg)
+    # keyword, text = message_keyword(msg)
 
-    message = ::MySlack::Commands.process(keyword, text, mention)
+    message = ::MySlack::Commands.process(msg, mention)
 
-    ::MySlack::client.chat_postMessage(message)
-  end
-
-  def message_keyword(text)
-    words = text.split(' ')
-    if words.first =~ /@[\w]+/
-      words.shift
-    end
-    [words.shift, words.join(' ')]
+    ::MySlack::client.chat_postMessage(message) unless message.nil?
   end
 
   def bot_match(word)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -29,6 +29,10 @@ class Person < ApplicationRecord
     self.update_attribute(:available, false)
   end
 
+  def update_email(email = nil)
+    self.update_attribute(:slack_email, email)
+  end
+
   def set_here(product = nil)
     Rails.logger.info product.inspect
     self.product = product

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -13,6 +13,9 @@
     = f.label :slack_id
     = f.text_field :slack_id
   .field
+    = f.label :slack_email
+    = f.text_field :slack_email
+  .field
     = f.label :slack_handle
     = f.text_field :slack_handle
   .field

--- a/app/views/people/_person.json.jbuilder
+++ b/app/views/people/_person.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! person, :id, :name, :slack_id, :slack_handle, :available, :product_id, :created_at, :updated_at
+json.extract! person, :id, :name, :slack_id, :slack_email, :slack_handle, :available, :product_id, :created_at, :updated_at
 json.url person_url(person, format: :json)

--- a/app/views/people/index.html.haml
+++ b/app/views/people/index.html.haml
@@ -5,6 +5,7 @@
     %tr
       %th Name
       %th Slack
+      %th Email
       %th Slack handle
       %th Available
       %th Product
@@ -17,6 +18,7 @@
       %tr
         %td= person.name
         %td= person.slack_id
+        %td= person.slack_email
         %td= person.slack_handle
         %td= person.available
         %td= person.product

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -7,6 +7,9 @@
   %b Slack:
   = @person.slack_id
 %p
+  %b Email:
+  = @person.slack_email
+%p
   %b Slack handle:
   = @person.slack_handle
 %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     post :actions, controller: 'slack'
     get :invalid_token, controller: 'slack'
     post :events, controller: 'slack'
+    post :interactive, controller: 'slack'
     
     resources :people, only: [] do
       collection do

--- a/db/migrate/20180627231145_add_slack_email_to_people.rb
+++ b/db/migrate/20180627231145_add_slack_email_to_people.rb
@@ -1,0 +1,5 @@
+class AddSlackEmailToPeople < ActiveRecord::Migration[5.1]
+  def change
+    add_column :people, :slack_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180309214102) do
+ActiveRecord::Schema.define(version: 20180627231145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20180309214102) do
     t.bigint "product_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slack_email"
     t.index ["product_id"], name: "index_people_on_product_id"
   end
 

--- a/lib/my_slack.rb
+++ b/lib/my_slack.rb
@@ -3,13 +3,21 @@ module MySlack
   ERROR = "#FF4136".freeze
   WARNING = "#FFA500".freeze
 
-
   def self.client
     unless @client
       @client = Slack::Web::Client.new
-      @client.auth_test
+      auth = @client.auth_test
+      @user_id = auth.user_id
     end
 
     @client
+  end
+
+  def self.user_id
+    @user_id
+  end
+
+  def self.identity
+    @identity ||= @client.users_info()
   end
 end

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -43,16 +43,50 @@ module MySlack
       }
     }
 
-    def self.process(name, text, data)
-      cmd = _find_command(name);
+    PLUGINS = [
+      proc { |text,data| MySlack::Commands::bot_commands(text, data) },
+      proc { |text,data| MySlack::Commands::watch_words(text, data) }
+    ]
 
-      Rails.logger.info "Running command: #{cmd}"
+    def self.watch_words(text, data)
+      message = nil
+      matched = text.match(/ZD[-]{0,1}([\d]+)/)
+      if matched
+        message = MySlack::Tickets::info(matched[1])
+      end
+
+      message
+    end
+
+    def self.command_for_me?(text, data)
+      first_word = text.split(/\s+/).first
+
+      data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/)
+    end
+
+    def self.bot_commands(text, data)
+      return unless command_for_me?(text, data)
+
+      keyword = _keyword(text)
+      cmd = _find_command(keyword);
+
+      Rails.logger.info "Running command: #{cmd}, #{data}"
       message = self.send(cmd, text, data)
+    end
 
-      message = message.as_json
-      message[:channel] ||= data['channel']
-      message[:as_user] = true
+    def self.process(text, data)
+      message = nil
+      PLUGINS.each do |plugin|
+        response = plugin.call(text, data)
 
+        unless response.nil?
+          message = response.as_json
+          message[:channel] ||= data['channel']
+          message[:as_user] = true
+          break
+        end
+
+      end
       message
     end
 
@@ -68,17 +102,35 @@ module MySlack
       end
 
       # return a message if we don't know
-      'not_implemented'
+      'unknown'
+    end
+
+    def self.mention?(text)
+
+    end
+
+    def self._keyword(text)
+      words = text.split(/\s+/)
+      # remove bot mention
+      if words.first =~ /@[\w]+/
+        words.shift
+      end
+      words.shift
     end
 
     class << self
       private
 
+      def identity
+      end
+
       def tickets(text, data = {})
         MySlack::Tickets.handle(text)
       end
 
-      def not_implemented(text, data = {})
+      def unknown(text, data = {})
+        return unless Rails.env.development?
+
         message = MySlack::Message::new()
         message.push_attachment({
           title: "I'm sorry <@#{data['user']}>, I'm afraid I can't do that",

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -121,16 +121,11 @@ module MySlack
     class << self
       private
 
-      def identity
-      end
-
       def tickets(text, data = {})
         MySlack::Tickets.handle(text)
       end
 
       def unknown(text, data = {})
-        return unless Rails.env.development?
-
         message = MySlack::Message::new()
         message.push_attachment({
           title: "I'm sorry <@#{data['user']}>, I'm afraid I can't do that",

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -21,6 +21,11 @@ module MySlack
         command: 'away',
         description: 'Mark yourself as away'
       },
+      update_email: {
+        match: %w{ update_email email },
+        command: 'update_email',
+        description: 'Update your associated Zendesk email'
+      },
       products: {
         match: %w{ products product },
         command: 'products [subcommand]',
@@ -108,6 +113,10 @@ module MySlack
 
       def away(text, data = {})
         MySlack::People.set_away(data['user'])
+      end
+
+      def update_email(text, data = {})
+        MySlack::People.update_email(data['user'], text)
       end
 
       def here(text, data = {})

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -50,7 +50,7 @@ module MySlack
 
     def self.watch_words(text, data)
       message = nil
-      matched = text.match(/ZD[-]{0,1}([\d]+)/)
+      matched = text.match(/ZD[-]{0,1}([\d]+)/i)
       if matched
         message = MySlack::Tickets::info(matched[1])
       end
@@ -71,7 +71,7 @@ module MySlack
       cmd = _find_command(keyword);
 
       Rails.logger.info "Running command: #{cmd}, #{data}"
-      message = self.send(cmd, text, data)
+      message = self.send(cmd, text, data) unless cmd == 'unknown'
     end
 
     def self.process(text, data)
@@ -83,7 +83,7 @@ module MySlack
           message = response.as_json
           message[:channel] ||= data['channel']
           message[:as_user] = true
-          break
+          return message
         end
       end
       message

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -38,16 +38,50 @@ module MySlack
       }
     }
 
-    def self.process(name, text, data)
-      cmd = _find_command(name);
+    PLUGINS = [
+      proc { |text,data| MySlack::Commands::bot_commands(text, data) },
+      proc { |text,data| MySlack::Commands::watch_words(text, data) }
+    ]
 
-      Rails.logger.info "Running command: #{cmd}"
+    def self.watch_words(text, data)
+      message = nil
+      matched = text.match(/ZD[-]{0,1}([\d]+)/)
+      if matched
+        message = MySlack::Tickets::info(matched[1])
+      end
+
+      message
+    end
+
+    def self.command_for_me?(text, data)
+      first_word = text.split(/\s+/).first
+
+      data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/)
+    end
+
+    def self.bot_commands(text, data)
+      return unless command_for_me?(text, data)
+
+      keyword = _keyword(text)
+      cmd = _find_command(keyword);
+
+      Rails.logger.info "Running command: #{cmd}, #{data}"
       message = self.send(cmd, text, data)
+    end
 
-      message = message.as_json
-      message[:channel] ||= data['channel']
-      message[:as_user] = true
+    def self.process(text, data)
+      message = nil
+      PLUGINS.each do |plugin|
+        response = plugin.call(text, data)
 
+        unless response.nil?
+          message = response.as_json
+          message[:channel] ||= data['channel']
+          message[:as_user] = true
+          break
+        end
+
+      end
       message
     end
 
@@ -63,17 +97,35 @@ module MySlack
       end
 
       # return a message if we don't know
-      'not_implemented'
+      'unknown'
+    end
+
+    def self.mention?(text)
+
+    end
+
+    def self._keyword(text)
+      words = text.split(/\s+/)
+      # remove bot mention
+      if words.first =~ /@[\w]+/
+        words.shift
+      end
+      words.shift
     end
 
     class << self
       private
 
+      def identity
+      end
+
       def tickets(text, data = {})
         MySlack::Tickets.handle(text)
       end
 
-      def not_implemented(text, data = {})
+      def unknown(text, data = {})
+        return unless Rails.env.development?
+
         message = MySlack::Message::new()
         message.push_attachment({
           title: "I'm sorry <@#{data['user']}>, I'm afraid I can't do that",

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -85,7 +85,6 @@ module MySlack
           message[:as_user] = true
           break
         end
-
       end
       message
     end

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -61,7 +61,7 @@ module MySlack
     def self.command_for_me?(text, data)
       first_word = text.split(/\s+/).first
 
-      data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/)
+      data['channel_type'] == 'im' || (data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/))
     end
 
     def self.bot_commands(text, data)
@@ -103,10 +103,6 @@ module MySlack
 
       # return a message if we don't know
       'unknown'
-    end
-
-    def self.mention?(text)
-
     end
 
     def self._keyword(text)

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -56,7 +56,7 @@ module MySlack
     def self.command_for_me?(text, data)
       first_word = text.split(/\s+/).first
 
-      data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/)
+      data['channel_type'] == 'im' || (data['type'] == 'app_mention' && first_word.match?(/@#{MySlack.user_id}/))
     end
 
     def self.bot_commands(text, data)
@@ -98,10 +98,6 @@ module MySlack
 
       # return a message if we don't know
       'unknown'
-    end
-
-    def self.mention?(text)
-
     end
 
     def self._keyword(text)

--- a/lib/my_slack/commands.rb
+++ b/lib/my_slack/commands.rb
@@ -116,16 +116,11 @@ module MySlack
     class << self
       private
 
-      def identity
-      end
-
       def tickets(text, data = {})
         MySlack::Tickets.handle(text)
       end
 
       def unknown(text, data = {})
-        return unless Rails.env.development?
-
         message = MySlack::Message::new()
         message.push_attachment({
           title: "I'm sorry <@#{data['user']}>, I'm afraid I can't do that",

--- a/lib/my_slack/products.rb
+++ b/lib/my_slack/products.rb
@@ -14,6 +14,8 @@ module MySlack
       def _parse_text(text)
         text.downcase!
         words = text.split(' ')
+        # strip off the products command word
+        words.shift
         [words.shift, words.join(' ')]
       end
 

--- a/lib/my_slack/tickets.rb
+++ b/lib/my_slack/tickets.rb
@@ -92,7 +92,7 @@ module MySlack
       def info(data)
         ticket = Ticket.where(zendesk_id: data).first_or_initialize
 
-        message = MySlack::Message.new()
+        message = MySlack::Message.new(text: ticket.zendesk_agent_url)
         message.push_attachment(ticket.zendesk_summary)
 
         message

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -17,7 +17,7 @@ class PeopleControllerTest < ActionDispatch::IntegrationTest
 
   test "should create person" do
     assert_difference('Person.count') do
-      post people_url, params: { person: { available: @person.available, name: @person.name, product_id: @person.product_id, slack_handle: @person.slack_handle, slack_id: @person.slack_id } }
+      post people_url, params: { person: { available: @person.available, name: @person.name, product_id: @person.product_id, slack_handle: @person.slack_handle, slack_id: @person.slack_id, slack_email: @person.slack_email } }
     end
 
     assert_redirected_to person_url(Person.last)
@@ -34,7 +34,7 @@ class PeopleControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update person" do
-    patch person_url(@person), params: { person: { available: @person.available, name: @person.name, product_id: @person.product_id, slack_handle: @person.slack_handle, slack_id: @person.slack_id } }
+    patch person_url(@person), params: { person: { available: @person.available, name: @person.name, product_id: @person.product_id, slack_handle: @person.slack_handle, slack_id: @person.slack_id, slack_email: @person.slack_email } }
     assert_redirected_to person_url(@person)
   end
 

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -4,6 +4,7 @@ one:
   name: MyString
   slack_id: MyString
   slack_handle: MyString
+  slack_email: MyString
   available: false
   product: one
 
@@ -11,5 +12,6 @@ two:
   name: MyString
   slack_id: MyString
   slack_handle: MyString
+  slack_email: MyString
   available: false
   product: two


### PR DESCRIPTION
this will make it easier to define different methods to handle different types of messages

1. app_mentions or messages that start with @botname 
2. messages that include a ZD-TICKETID like text that will automatically link to the ticket
3. anything else we need it to handle for us based on the content of a message